### PR TITLE
Fix wrong inl include

### DIFF
--- a/source/cppassist/include/cppassist/memory/offsetof.h
+++ b/source/cppassist/include/cppassist/memory/offsetof.h
@@ -16,4 +16,4 @@ std::ptrdiff_t offset(Type Class::*member);
 } // namespace cppassist
 
 
-#include <cppassist/memory/offsetof.hpp>
+#include <cppassist/memory/offsetof.inl>


### PR DESCRIPTION
What is the point of this function anyway? Why not use the standard macro?