### PR TITLE
WIP: Collect function

### DIFF
--- a/source/cppassist/CMakeLists.txt
+++ b/source/cppassist/CMakeLists.txt
@@ -99,6 +99,8 @@ set(headers
     ${include_path}/cmdline/CommandLineOption.h
     ${include_path}/cmdline/CommandLineSwitch.h
     ${include_path}/cmdline/CommandLineParameter.h
+
+    ${include_path}/algorithm/collect.h
 )
 
 set(sources

--- a/source/cppassist/include/cppassist/algorithm/collect.h
+++ b/source/cppassist/include/cppassist/algorithm/collect.h
@@ -116,7 +116,7 @@ ResultType collect(const SourceType & source, const Function & f)
     using std::inserter;
 
     auto result = detail::Instantiator<SourceType, ResultType>::create(source);
-    std::transform(begin(source), end(source), inserter(result, end(result)), f);
+    std::transform(begin(source), end(source), inserter(result, begin(result)), f);
     return result;
 }
 

--- a/source/cppassist/include/cppassist/algorithm/collect.h
+++ b/source/cppassist/include/cppassist/algorithm/collect.h
@@ -133,7 +133,7 @@ auto collect(const BaseContainer<SourceValueType, Args<SourceValueType>...> & so
 -> typename detail::Container<BaseContainer, detail::ResultValueType<SourceValueType, Function>, Args...>::Type
 {
     return collect<typename detail::Container<BaseContainer, detail::ResultValueType<SourceValueType, Function>, Args...>::Type>(source, f);
-};
+}
 
 template <
     typename Function
@@ -149,7 +149,7 @@ template <
 ResultType collect(const std::map<SourceKeyType, SourceValueType, Compare<SourceKeyType>, Allocator<std::pair<const SourceKeyType, SourceValueType>>> & source, const Function & f)
 {
     return collect<ResultType>(source, f);
-};
+}
 
 template <
     typename Function
@@ -166,7 +166,7 @@ template <
 ResultType collect(const std::unordered_map<SourceKeyType, SourceValueType, Hash<SourceKeyType>, EqualTo<SourceKeyType>, Allocator<std::pair<const SourceKeyType, SourceValueType>>> & source, const Function & f)
 {
     return collect<ResultType>(source, f);
-};
+}
 
 
 // Result container differs from source container
@@ -180,7 +180,7 @@ template <
 ResultType collect(const SourceType & source, const Function & f)
 {
     return collect<ResultType>(source, f);
-};
+}
 
 template <
     template <typename...> class BaseContainer
@@ -192,7 +192,7 @@ template <
 ResultType collect(const SourceType & source, const Function & f)
 {
     return collect<ResultType>(source, f);
-};
+}
 
 template <
     template <typename...> class BaseContainer
@@ -205,7 +205,7 @@ template <
 ResultType collect(const SourceType & source, const Function & f)
 {
     return collect<ResultType>(source, f);
-};
+}
 
 template <
     template <typename...> class BaseContainer
@@ -219,7 +219,7 @@ template <
 ResultType collect(const SourceType & source, const Function & f)
 {
     return collect<ResultType>(source, f);
-};
+}
 
 template <
     template <typename...> class BaseContainer
@@ -234,7 +234,7 @@ template <
 ResultType collect(const SourceType & source, const Function & f)
 {
     return collect<ResultType>(source, f);
-};
+}
 
 
 } // namespace algorithm

--- a/source/cppassist/include/cppassist/algorithm/collect.h
+++ b/source/cppassist/include/cppassist/algorithm/collect.h
@@ -1,0 +1,241 @@
+
+#pragma once
+
+
+#include <utility>
+#include <type_traits>
+#include <unordered_map>
+#include <map>
+
+
+namespace cppassist
+{
+namespace algorithm
+{
+
+
+namespace detail
+{
+
+
+// Get result type of converter function
+
+template <typename SourceValueType, typename Function>
+using ResultValueType = typename std::result_of<Function(SourceValueType)>::type;
+
+template <typename SourceType, typename Function>
+using ResultValueTypeFromContainer = ResultValueType<typename SourceType::value_type, Function>;
+
+
+// Fully specify a base container template for a value type and a variable number of other arguments
+
+template <template <typename...> class BaseContainer, typename ValueType, template <typename> class... Args>
+struct Container
+{
+    using Type = BaseContainer<ValueType, Args<ValueType>...>;
+};
+
+// specializations for map
+
+template <typename ValueType>
+struct Container<std::map, ValueType>
+{
+    using Type = std::map<typename ValueType::first_type, typename ValueType::second_type>;
+};
+
+template <typename ValueType, template <typename> class Compare>
+struct Container<std::map, ValueType, Compare>
+{
+    using Type = std::map<typename ValueType::first_type, typename ValueType::second_type, Compare<typename ValueType::first_type>>;
+};
+
+template <typename ValueType, template <typename> class Compare, template <typename> class Allocator>
+struct Container<std::map, ValueType, Compare, Allocator>
+{
+    using Type = std::map<typename ValueType::first_type, typename ValueType::second_type, Compare<typename ValueType::first_type>, Allocator<std::pair<const typename ValueType::first_type, typename ValueType::second_type>>>;
+};
+
+// specializations for unordered_map
+
+template <typename ValueType>
+struct Container<std::unordered_map, ValueType>
+{
+    using Type = std::unordered_map<typename ValueType::first_type, typename ValueType::second_type>;
+};
+
+template <typename ValueType, template <typename> class Hash>
+struct Container<std::unordered_map, ValueType, Hash>
+{
+    using Type = std::unordered_map<typename ValueType::first_type, typename ValueType::second_type, Hash<typename ValueType::first_type>>;
+};
+
+template <typename ValueType, template <typename> class Hash, template <typename> class EqualTo>
+struct Container<std::unordered_map, ValueType, Hash, EqualTo>
+{
+    using Type = std::unordered_map<typename ValueType::first_type, typename ValueType::second_type, Hash<typename ValueType::first_type>, EqualTo<typename ValueType::first_type>>;
+};
+
+template <typename ValueType, template <typename> class Hash, template <typename> class EqualTo, template <typename> class Allocator>
+struct Container<std::unordered_map, ValueType, Hash, EqualTo, Allocator>
+{
+    using Type = std::unordered_map<typename ValueType::first_type, typename ValueType::second_type, Hash<typename ValueType::first_type>, EqualTo<typename ValueType::first_type>, Allocator<std::pair<const typename ValueType::first_type, typename ValueType::second_type>>>;
+};
+
+
+// Instantiate with a copy of the source allocator, if present
+
+template <typename SourceType, typename ResultType, typename Enable = void>
+struct Instantiator
+{
+    static ResultType create(const SourceType &)
+    {
+        return ResultType{};
+    }
+};
+
+template <typename SourceType, typename ResultType>
+struct Instantiator<SourceType, ResultType, typename SourceType::allocator_type>
+{
+    static ResultType create(const SourceType & source)
+    {
+        return ResultType{ source.get_allocator() };
+    }
+};
+
+
+} // namespace detail
+
+
+// Fully specified container type
+
+template <typename ResultType, typename SourceType, typename Function>
+ResultType collect(const SourceType & source, const Function & f)
+{
+    using std::begin;
+    using std::end;
+    using std::inserter;
+
+    auto result = detail::Instantiator<SourceType, ResultType>::create(source);
+    std::transform(begin(source), end(source), inserter(result, end(result)), f);
+    return result;
+}
+
+
+// Result container matches source container
+
+template <
+    template <typename...> class BaseContainer
+  , typename Function
+  , typename SourceValueType
+  , template <typename> class ... Args
+>
+auto collect(const BaseContainer<SourceValueType, Args<SourceValueType>...> & source, const Function & f)
+-> typename detail::Container<BaseContainer, detail::ResultValueType<SourceValueType, Function>, Args...>::Type
+{
+    return collect<typename detail::Container<BaseContainer, detail::ResultValueType<SourceValueType, Function>, Args...>::Type>(source, f);
+};
+
+template <
+    typename Function
+  , typename SourceKeyType
+  , typename SourceValueType
+  , template <typename> class Compare
+  , template <typename> class Allocator
+  , typename CompoundType = detail::ResultValueType<std::pair<const SourceKeyType, SourceValueType>, Function>
+  , typename KeyType = typename CompoundType::first_type
+  , typename ValueType = typename CompoundType::second_type
+  , typename ResultType = std::map<KeyType, ValueType, Compare<KeyType>, Allocator<std::pair<const KeyType, ValueType>>>
+>
+ResultType collect(const std::map<SourceKeyType, SourceValueType, Compare<SourceKeyType>, Allocator<std::pair<const SourceKeyType, SourceValueType>>> & source, const Function & f)
+{
+    return collect<ResultType>(source, f);
+};
+
+template <
+    typename Function
+  , typename SourceKeyType
+  , typename SourceValueType
+  , template <typename> class Hash
+  , template <typename> class EqualTo
+  , template <typename> class Allocator
+  , typename CompoundType = detail::ResultValueType<std::pair<const SourceKeyType, SourceValueType>, Function>
+  , typename KeyType = typename CompoundType::first_type
+  , typename ValueType = typename CompoundType::second_type
+  , typename ResultType = std::unordered_map<KeyType, ValueType, Hash<KeyType>, EqualTo<KeyType>, Allocator<std::pair<const KeyType, ValueType>>>
+>
+ResultType collect(const std::unordered_map<SourceKeyType, SourceValueType, Hash<SourceKeyType>, EqualTo<SourceKeyType>, Allocator<std::pair<const SourceKeyType, SourceValueType>>> & source, const Function & f)
+{
+    return collect<ResultType>(source, f);
+};
+
+
+// Result container differs from source container
+
+template <
+    template <typename...> class BaseContainer
+  , typename SourceType
+  , typename Function
+  , typename ResultType = typename detail::Container<BaseContainer, detail::ResultValueTypeFromContainer<SourceType, Function>>::Type
+>
+ResultType collect(const SourceType & source, const Function & f)
+{
+    return collect<ResultType>(source, f);
+};
+
+template <
+    template <typename...> class BaseContainer
+  , template <typename> class Arg1
+  , typename SourceType
+  , typename Function
+  , typename ResultType = typename detail::Container<BaseContainer, detail::ResultValueTypeFromContainer<SourceType, Function>, Arg1>::Type
+>
+ResultType collect(const SourceType & source, const Function & f)
+{
+    return collect<ResultType>(source, f);
+};
+
+template <
+    template <typename...> class BaseContainer
+  , template <typename> class Arg1
+  , template <typename> class Arg2
+  , typename SourceType
+  , typename Function
+  , typename ResultType = typename detail::Container<BaseContainer, detail::ResultValueTypeFromContainer<SourceType, Function>, Arg1, Arg2>::Type
+>
+ResultType collect(const SourceType & source, const Function & f)
+{
+    return collect<ResultType>(source, f);
+};
+
+template <
+    template <typename...> class BaseContainer
+  , template <typename> class Arg1
+  , template <typename> class Arg2
+  , template <typename> class Arg3
+  , typename SourceType
+  , typename Function
+  , typename ResultType = typename detail::Container<BaseContainer, detail::ResultValueTypeFromContainer<SourceType, Function>, Arg1, Arg2, Arg3>::Type
+>
+ResultType collect(const SourceType & source, const Function & f)
+{
+    return collect<ResultType>(source, f);
+};
+
+template <
+    template <typename...> class BaseContainer
+  , template <typename> class Arg1
+  , template <typename> class Arg2
+  , template <typename> class Arg3
+  , template <typename> class Arg4
+  , typename SourceType
+  , typename Function
+  , typename ResultType = typename detail::Container<BaseContainer, detail::ResultValueTypeFromContainer<SourceType, Function>, Arg1, Arg2, Arg3, Arg4>::Type
+>
+ResultType collect(const SourceType & source, const Function & f)
+{
+    return collect<ResultType>(source, f);
+};
+
+
+} // namespace algorithm
+} // namespace cppassist

--- a/source/tests/cppassist-test/CMakeLists.txt
+++ b/source/tests/cppassist-test/CMakeLists.txt
@@ -32,6 +32,9 @@ set(sources
     # io
     manipulation_test.cpp
     conversion_test.cpp
+
+    # algorithm
+    collect_test.cpp
 )
 
 

--- a/source/tests/cppassist-test/collect_test.cpp
+++ b/source/tests/cppassist-test/collect_test.cpp
@@ -1,0 +1,7 @@
+
+#include <gmock/gmock.h>
+
+#include <cppassist/algorithm/collect.h>
+
+
+using namespace cppassist;

--- a/source/tests/cppassist-test/collect_test.cpp
+++ b/source/tests/cppassist-test/collect_test.cpp
@@ -1,7 +1,144 @@
 
+#include <array>
+#include <deque>
+
 #include <gmock/gmock.h>
 
 #include <cppassist/algorithm/collect.h>
 
 
 using namespace cppassist;
+using namespace algorithm;
+
+
+template <typename T>
+struct Allocator : std::allocator<T>
+{
+};
+
+
+std::string convert_single(int value)
+{
+    return std::to_string(value);
+}
+
+
+std::initializer_list<int> m_initializerList{ -9198880, 96801928, 33316728, 80982026, 73853833, 99971965, 23515878, 6745749, 92276312, 98113098, 32261739, 21064214, 66415596, 133095, 10045572, 5303144, 22491772, 51711666, 70331437, 25908160, 31697032, 55834366, 35188552, 67849937, 98808105, 70907294, -9613997, 23250575, 95022988, 68193511, 87563398, 52809751, 36033138, 42154455, 54887718, -4039754, 57354576, 169149, 42665666, 97753461, 95360868, 96799748, 60700786, 20997325, 81748150, 16506436, 16077645, 51048746, 82137829, 79490438, 72783078, 45621069, 80713200, 51011807, -7803670, 3971706, 30664231, 14083839, 98095515, 45224232, 73251632, 41798654, 68831824, 48528297, 94830658, 78248670, -4161288, 53452001, 13000660, 37268037, 65307089, 1654799, 87138676, 47987886, 93797628, 81439532, 72113831, 28904197, 71551224, 56687182, 78956061, -4817618, 87974845, 11380998, 28235787, 85853654, 15441905, 76937671, 60102535, 95427036, 52138877, 40771972, 30374146, 16942904, 55758609, 25340282, 31111953, 98998649, 85201389, 20761381, 19655223, 76168045, 37289358, 78703112, 87174641, 98820755, 85008583, -9635965, -164978, 1313791, 52090956, -7295670, 33164976, 28568687, 51792151, -1561546, 43009793, 77908749, 61924982, 48174281, 92053179, 36754799, -6955856, 33115679, -9651549, 2999886, 32376221, 17128209, 18079733, 82986782, 55005738, 58598535, 47586971, 54237365, 60308088, 97016328, 2427944, -8381286, 65003999, 60459239, 61821067, 14338873, 19222313, 83714820, 29334109, 16987422, 5376509, 30367549, 14792497, 2753075, 87884628, 23664279, -5466075, 5393437, -8149813, 21355673, 76283021, -7437434, 25006615, -7764216, 66775240, 57181117, 60561716, 59417296, -1147023, 52726011, 68929290, 83047595, 6628231, 6524668, 42048630, 12388460, -2762535, 30174029, 97860929, 14496811, 35957725, -1681732, 12695404, 80044445, 55682481, 74229067, 14433306, 11217077, 9350579, -5575616, -1299904, 72222620, 34385541, 54913304, 39712414, 24065764, 59950211, 21276987, 19976760, 89318883, 10990521, 81703367, 29237646, 40192470, 37750981, 99903172, 73652026, 28048718, 3293911, 32934055, 71364647, -9126774, 13113372, -2953198, -8979185, 17896930, 97961542, 83883421, -4867150, 17922700, 27669503, 91621231, 8337023, 5249372, 72626043, 19944096, 72085111, 27342751, 97129062, 42551879, 53727192, 14282314, 45124548, 56623528, 92903288, 65505260, 58487895, 87055749, 68790587, 24672356, 44333757, 24434520, 29083787, 9515994, 2672843, 45266142, 38205545, 77599395, 74881379, 18595614, 76448122, 16860211, 1264825, 41152548, 3264856, 66538223, 78817687, -6165507, 5006250, 10285952 };
+
+
+class collect_test : public testing::Test
+{
+public:
+    collect_test()
+    {
+        auto arrayItr = m_array.begin();
+        for (auto v : m_initializerList)
+        {
+            *arrayItr++ = v;
+            m_vector.push_back(v);
+            m_vectorAllocator.push_back(v);
+            m_deque.push_back(v);
+            m_dequeAllocator.push_back(v);
+            m_list.push_back(v);
+            m_listAllocator.push_back(v);
+
+            m_expectedSingle.push_back(convert_single(v));
+        }
+    }
+
+protected:
+    template <typename T>
+    bool equalExpected(const T & container)
+    {
+        return std::equal(container.begin(), container.end(), m_expectedSingle.begin(), m_expectedSingle.end());
+    }
+
+protected:
+    std::vector<std::string> m_expectedSingle;
+
+    std::array<int, 256> m_array;
+    std::vector<int> m_vector;
+    std::vector<int, Allocator<int>> m_vectorAllocator;
+    std::deque<int> m_deque;
+    std::deque<int, Allocator<int>> m_dequeAllocator;
+    std::list<int> m_list;
+    std::list<int, Allocator<int>> m_listAllocator;
+};
+
+
+template <typename Expected, typename Container>
+void static_assert_allocator(const Container &)
+{
+    static_assert(std::is_same<typename Container::allocator_type, Expected>::value, "Allocator type mismatch");
+}
+
+
+TEST_F(collect_test, vector_equal)
+{
+    const auto fromInitializerList = collect<std::vector>(m_initializerList, &convert_single);
+    const auto fromVector          = collect<std::vector>(m_vector,          &convert_single);
+    const auto fromVectorAllocator = collect<std::vector>(m_vectorAllocator, &convert_single);
+    const auto fromDeque           = collect<std::vector>(m_deque,           &convert_single);
+    const auto fromDequeAllocator  = collect<std::vector>(m_dequeAllocator,  &convert_single);
+    const auto fromList            = collect<std::vector>(m_list,            &convert_single);
+    const auto fromListAllocator   = collect<std::vector>(m_listAllocator,   &convert_single);
+
+    static_assert_allocator<std::allocator<std::string>>(fromInitializerList);
+    static_assert_allocator<std::allocator<std::string>>(fromVector);
+    static_assert_allocator<Allocator<std::string>>(fromVectorAllocator);
+    static_assert_allocator<std::allocator<std::string>>(fromDeque);
+    static_assert_allocator<std::allocator<std::string>>(fromDequeAllocator);
+    static_assert_allocator<std::allocator<std::string>>(fromList);
+    static_assert_allocator<std::allocator<std::string>>(fromListAllocator);
+
+    EXPECT_TRUE(equalExpected(fromInitializerList));
+    EXPECT_TRUE(equalExpected(fromVector));
+    EXPECT_TRUE(equalExpected(fromVectorAllocator));
+    EXPECT_TRUE(equalExpected(fromDeque));
+    EXPECT_TRUE(equalExpected(fromDequeAllocator));
+    EXPECT_TRUE(equalExpected(fromList));
+    EXPECT_TRUE(equalExpected(fromListAllocator));
+}
+
+
+TEST_F(collect_test, vector_source_allocator)
+{
+    const auto fromInitializerList = collect<std::vector>(m_initializerList, &convert_single);
+    const auto fromVector          = collect<std::vector>(m_vector,          &convert_single);
+    const auto fromVectorAllocator = collect<std::vector>(m_vectorAllocator, &convert_single);
+    const auto fromDeque           = collect<std::vector>(m_deque,           &convert_single);
+    const auto fromDequeAllocator  = collect<std::vector>(m_dequeAllocator,  &convert_single);
+    const auto fromList            = collect<std::vector>(m_list,            &convert_single);
+    const auto fromListAllocator   = collect<std::vector>(m_listAllocator,   &convert_single);
+
+    static_assert_allocator<std::allocator<std::string>>(fromInitializerList);
+    static_assert_allocator<std::allocator<std::string>>(fromVector);
+    static_assert_allocator<Allocator<std::string>>(fromVectorAllocator);
+    static_assert_allocator<std::allocator<std::string>>(fromDeque);
+    static_assert_allocator<std::allocator<std::string>>(fromDequeAllocator);
+    static_assert_allocator<std::allocator<std::string>>(fromList);
+    static_assert_allocator<std::allocator<std::string>>(fromListAllocator);
+}
+
+
+TEST_F(collect_test, vector_result_allocator)
+{
+    const auto withCustomAllocator = collect<std::vector, Allocator>(m_vector, &convert_single);
+    const auto withStdAllocator    = collect<std::vector, std::allocator>(m_vectorAllocator, &convert_single);
+
+    static_assert_allocator<Allocator<std::string>>(withCustomAllocator);
+    static_assert_allocator<std::allocator<std::string>>(withStdAllocator);
+}
+
+
+TEST_F(collect_test, vector_same_type)
+{
+    const auto fromVector          = collect(m_vector, &convert_single);
+    const auto fromVectorAllocator = collect(m_vectorAllocator, &convert_single);
+
+    static_assert_allocator<std::allocator<std::string>>(fromVector);
+    static_assert_allocator<Allocator<std::string>>(fromVectorAllocator);
+
+    EXPECT_TRUE(equalExpected(fromVector));
+    EXPECT_TRUE(equalExpected(fromVectorAllocator));
+}


### PR DESCRIPTION
TODO:
- [ ] Finish extensive tests
- [ ] Document
- [ ] Move implementations to inl file

Current limitations:
- Additional container template arguments (e.g., Comparator, Allocator) are only adopted if source and result container are the same.
- Passing a free function as converter requires explicit pointer operator (e.g., `&myFunc`, not `myFunc`)