### PR TITLE
Add TypeList module and class

### DIFF
--- a/source/cppassist/CMakeLists.txt
+++ b/source/cppassist/CMakeLists.txt
@@ -96,6 +96,9 @@ set(headers
 
     ${include_path}/threading/parallelfor.h
     ${include_path}/threading/parallelfor.inl
+    
+    ${include_path}/typelist/TypeList.h
+    ${include_path}/typelist/TypeList.inl
 
     ${include_path}/cmdline/ArgumentParser.h
     ${include_path}/cmdline/ArgumentParser.inl

--- a/source/cppassist/include/cppassist/typelist/TypeList.h
+++ b/source/cppassist/include/cppassist/typelist/TypeList.h
@@ -1,0 +1,68 @@
+
+#pragma once
+
+
+namespace cppassist
+{
+
+
+/**
+*  @brief
+*    A compile-time list of types.
+*
+*    This is the default template for template specializations.
+*/
+template <typename... Types>
+class TypeList;
+
+/**
+*  @brief
+*    A compile-time list of types.
+*
+*    This is the template specialization for non-zero type lists.
+*    There is an interface to call a template operator() on a Functor for each type in the type list.
+*/
+template <typename T, typename... Types>
+class TypeList<T, Types...>
+{
+public:
+    /**
+    *  @brief
+    *    Call the template operator() on the Functor for each type.
+    *
+    *  @param[in] callback
+    *    The functor, supporting a templated operator()
+    */
+    template <typename Functor>
+    static void apply(Functor && callback);
+};
+
+/**
+*  @brief
+*    A compile-time list of types.
+*
+*    This is the template specialization for a zero type list.
+*    It is used as the recursion break condition.
+*/
+template <>
+class TypeList<>
+{
+public:
+    /**
+    *  @brief
+    *    Call the template operator() on the Functor for each type.
+    *
+    *    As this is the empty type list, no operator is called.
+    *
+    *  @param[in] callback
+    *    The functor, supporting a templated operator()
+    */
+    template <typename Functor>
+    static void apply(Functor && callback);
+};
+
+
+} // namespace cppassist
+
+
+#include <cppassist/typelist/TypeList.inl>

--- a/source/cppassist/include/cppassist/typelist/TypeList.inl
+++ b/source/cppassist/include/cppassist/typelist/TypeList.inl
@@ -1,0 +1,27 @@
+
+#pragma once
+
+
+#include <utility>
+
+
+namespace cppassist
+{
+
+
+template <typename T, typename... Types>
+template <typename Functor>
+void TypeList<T, Types...>::apply(Functor && callback)
+{
+    (callback.template operator()<T>)();
+
+    TypeList<Types...>::apply(std::forward<Functor>(callback));
+}
+
+template <typename Functor>
+void TypeList<>::apply(Functor && /*callback*/)
+{
+}
+
+
+} // namespace cppassist

--- a/source/tests/cppassist-test/CMakeLists.txt
+++ b/source/tests/cppassist-test/CMakeLists.txt
@@ -35,6 +35,9 @@ set(sources
     
     # flags
     flags_test.cpp
+    
+    # typelist
+    typelist_test.cpp
 
     # memory
     make_unique_test.cpp

--- a/source/tests/cppassist-test/typelist_test.cpp
+++ b/source/tests/cppassist-test/typelist_test.cpp
@@ -1,0 +1,51 @@
+
+#include <gmock/gmock.h>
+
+#include <cppassist/typelist/TypeList.h>
+
+
+class typelist_test : public testing::Test
+{
+public:
+    typelist_test()
+    : intCallcount(0)
+    , floatCallcount(0)
+    , boolCallcount(0)
+    {
+    }
+
+    template <typename T>
+    void operator()()
+    {
+        if (typeid(T) == typeid(int))
+        {
+            ++intCallcount;
+        }
+
+        if (typeid(T) == typeid(float))
+        {
+            ++floatCallcount;
+        }
+
+        if (typeid(T) == typeid(bool))
+        {
+            ++boolCallcount;
+        }
+    }
+protected:
+    int intCallcount;
+    int floatCallcount;
+    int boolCallcount;
+};
+
+
+TEST_F(typelist_test, ListApply)
+{
+    using list = cppassist::TypeList<int, float, bool>;
+
+    list::apply(*this);
+
+    ASSERT_EQ(intCallcount, 1);
+    ASSERT_EQ(floatCallcount, 1);
+    ASSERT_EQ(boolCallcount, 1);
+}


### PR DESCRIPTION
This PR introduces a new module to cppassist: `typelist`.
I'm not happy with another module within cppassist. However, there is currently no other module where the `TypeList` can be meaningfully placed into. Maybe we should merge some modules.

The `TypeList` is required by https://github.com/cginternals/gloperate/pull/379.