### PR TITLE
Change TypeName::apply's Functor's method name

### DIFF
--- a/source/cppassist/include/cppassist/typelist/TypeList.h
+++ b/source/cppassist/include/cppassist/typelist/TypeList.h
@@ -20,7 +20,7 @@ class TypeList;
 *    A compile-time list of types.
 *
 *    This is the template specialization for non-zero type lists.
-*    There is an interface to call a template operator() on a Functor for each type in the type list.
+*    There is an interface to call a template method invoke() on a Functor for each type in the type list.
 */
 template <typename T, typename... Types>
 class TypeList<T, Types...>
@@ -28,10 +28,10 @@ class TypeList<T, Types...>
 public:
     /**
     *  @brief
-    *    Call the template operator() on the Functor for each type.
+    *    Call the template method invoke() on the Functor for each type.
     *
     *  @param[in] callback
-    *    The functor, supporting a templated operator()
+    *    The functor, supporting a templated method invoke()
     */
     template <typename Functor>
     static void apply(Functor && callback);
@@ -50,12 +50,12 @@ class TypeList<>
 public:
     /**
     *  @brief
-    *    Call the template operator() on the Functor for each type.
+    *    Call the template method invoke() on the Functor for each type.
     *
     *    As this is the empty type list, no operator is called.
     *
     *  @param[in] callback
-    *    The functor, supporting a templated operator()
+    *    The functor, supporting a templated method invoke()
     */
     template <typename Functor>
     static void apply(Functor && callback);

--- a/source/cppassist/include/cppassist/typelist/TypeList.inl
+++ b/source/cppassist/include/cppassist/typelist/TypeList.inl
@@ -13,7 +13,7 @@ template <typename T, typename... Types>
 template <typename Functor>
 void TypeList<T, Types...>::apply(Functor && callback)
 {
-    (callback.template operator()<T>)();
+    callback.template invoke<T>();
 
     TypeList<Types...>::apply(std::forward<Functor>(callback));
 }

--- a/source/tests/cppassist-test/typelist_test.cpp
+++ b/source/tests/cppassist-test/typelist_test.cpp
@@ -15,7 +15,7 @@ public:
     }
 
     template <typename T>
-    void operator()()
+    void invoke()
     {
         if (typeid(T) == typeid(int))
         {


### PR DESCRIPTION
Functor now requires `invoke<T>()` instead of `operator()<T>()`

Requested because `(callback.template operator()<T>)();` was misinterpreted by MSVC, but `template` keyword is required by some other compilers.