### PR TITLE
Add missing include to parallel_for_test

### DIFF
--- a/source/tests/cppassist-test/parallel_for_test.cpp
+++ b/source/tests/cppassist-test/parallel_for_test.cpp
@@ -1,4 +1,5 @@
 
+#include <cstdint>
 #include <thread>
 
 #include <gmock/gmock.h>


### PR DESCRIPTION
Necessary for compilation with MSVC 2013